### PR TITLE
Fix incorrect IDs for Food category

### DIFF
--- a/taxonomy
+++ b/taxonomy
@@ -61,19 +61,19 @@
     <top_level id="102" title="Food">
         <second_level id="102-01" title="Community Gardens">
         </second_level>
-        <second_level id="101-02" title="Emergency Food">
+        <second_level id="102-02" title="Emergency Food">
         </second_level>
-        <second_level id="101-03" title="Food Delivery">
+        <second_level id="102-03" title="Food Delivery">
 		</second_level>
-        <second_level id="101-04" title="Food Pantry">
+        <second_level id="102-04" title="Food Pantry">
 		</second_level>
-        <second_level id="101-05" title="Free Meals">
+        <second_level id="102-05" title="Free Meals">
 		</second_level>
-        <second_level id="101-06" title="Help Pay for Food">
-            <third_level id="101-06-02" title="Food Benefits">
+        <second_level id="102-06" title="Help Pay for Food">
+            <third_level id="102-06-02" title="Food Benefits">
 			</third_level>
 		</second_level>
-		<second_level id="101-07" title="Nutrition">
+		<second_level id="102-07" title="Nutrition">
 		</second_level>
 	</top_level>	
     <top_level id="103" title="Housing">


### PR DESCRIPTION
Food was using 101 for many of its top and second level categories instead of 102.
